### PR TITLE
Remove db prefix option from installation command as its not available anymore since v20

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,8 +52,6 @@ nextcloud_database:
   port: 3306
   # The port the db server listens on
 
-  prefix: oc_
-  # Prefix for the nextcloud tables in the database.
 # }}}
 # Core configuration {{{
 # TODO make this part of nextcloud_config_system

--- a/tasks/core/install.yml
+++ b/tasks/core/install.yml
@@ -66,7 +66,6 @@
           --database-pass "{{ nextcloud_database.pass }}"
           --database-host "{{ nextcloud_database.host }}"
           --database-port "{{ nextcloud_database.port }}"
-          --database-table-prefix "{{ nextcloud_database.prefix }}"
           --admin-user "{{ nextcloud_admin_user }}"
           --admin-pass "{{ nextcloud_admin_pass }}"
           --data-dir "{{ nextcloud_data_dir }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -25,6 +25,3 @@ _nextcloud_database:
 
   port: 3306
   # The port the db server listens on
-
-  prefix: oc_
-  # Prefix for the nextcloud tables in the database.


### PR DESCRIPTION
This will simply remove `--database-table-prefix` and related variables from the role as the db prefix option was removed from cli install command since v20, see nextcloud/server#21112